### PR TITLE
Update jquery.calculator.js

### DIFF
--- a/jquery.calculator.js
+++ b/jquery.calculator.js
@@ -725,6 +725,10 @@ $.extend(Calculator.prototype, {
 			if (inst && inst._inline) {
 				inst._input.blur();
 			}
+			else{
+			    inst._input.focus();
+			    handled = true;
+			}
 		}
 		else if (plugin._showingCalculator ||
 				(div && !plugin._isDisabledPlugin(div))) {


### PR DESCRIPTION
Handled the TAB key in case of Non Inline calculator so that the focus is set back to the base control when you Tab out of the calculator control
